### PR TITLE
Added UTMs decorator

### DIFF
--- a/src/components/pages/Home/GetStarted/GetStarted.tsx
+++ b/src/components/pages/Home/GetStarted/GetStarted.tsx
@@ -7,7 +7,7 @@ import Button from "@/components/ui/button/Button";
 import { ButtonTypes } from "@/components/ui/button/types";
 import Github from "@/components/ui/icons/Github";
 import { GET_STARTED } from "@/utils/constants";
-import Link from "next/link";
+import Link from "@/components/ui/Link";
 
 const GetStarted = () => {
   const {

--- a/src/components/pages/Home/Hero/Hero.tsx
+++ b/src/components/pages/Home/Hero/Hero.tsx
@@ -19,7 +19,7 @@ import {
   useRelativeElementPositions,
 } from "@/hooks/useRelativeElementPositions";
 import { LineCoordinate } from "@/lib/types/paths";
-import Link from "next/link";
+import Link from "@/components/ui/Link";
 
 const Hero = () => {
   const containerRef = useRef<HTMLDivElement | null>(null);

--- a/src/components/ui/Buttons/DownloadButton.tsx
+++ b/src/components/ui/Buttons/DownloadButton.tsx
@@ -1,6 +1,6 @@
 // Dependencies
 import Image from "next/image";
-import Link from "next/link";
+import Link from "@/components/ui/Link";
 
 // Components
 import Display from "@/components/ui/Display";

--- a/src/components/ui/Header/Header.tsx
+++ b/src/components/ui/Header/Header.tsx
@@ -3,7 +3,7 @@
 // Dependencies
 import Image from "next/image";
 import { useRef, useState } from "react";
-import Link from "next/link";
+import Link from "@/components/ui/Link";
 
 // Components
 import Badge from "@/components/ui/Header/Badge";

--- a/src/components/ui/Link/Link.tsx
+++ b/src/components/ui/Link/Link.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+// Dependencies
+import BaseLink from "next/link";
+import { forwardRef, type ComponentProps, type PropsWithChildren } from "react";
+
+// Hooks
+import useDecoratedUrl from "@/hooks/useDecoratedUrl";
+
+// Props types
+type Props = PropsWithChildren<
+  ComponentProps<typeof BaseLink> & {
+    // Any other property goes here
+  }
+>;
+
+const Link = forwardRef<HTMLAnchorElement, Props>(
+  ({ children, href, ...props }, ref): JSX.Element => {
+    // Hooks
+    const url = useDecoratedUrl(href, /^(utm_)/);
+
+    if (!url) {
+      return <>{children}</>;
+    }
+
+    return (
+      <BaseLink href={url} {...props} ref={ref}>
+        {children}
+      </BaseLink>
+    );
+  }
+);
+
+Link.displayName = "Link";
+
+export default Link;

--- a/src/components/ui/Link/index.ts
+++ b/src/components/ui/Link/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./Link";

--- a/src/components/ui/Topbar/Topbar.tsx
+++ b/src/components/ui/Topbar/Topbar.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import Display from "@/components/ui/Display";
 import { Weight } from "@/components/ui/Display/types";
 import styles from "./styles.module.scss";
-import Link from "next/link";
+import Link from "@/components/ui/Link";
 import Speaker from "../icons/Speaker";
 
 interface Props {

--- a/src/components/ui/footer/Footer.tsx
+++ b/src/components/ui/footer/Footer.tsx
@@ -6,7 +6,7 @@ import { SOCIALS } from "@/utils/constants";
 
 // Styles
 import styles from "./styles.module.scss";
-import Link from "next/link";
+import Link from "@/components/ui/Link";
 
 const Footer = () => {
   return (

--- a/src/hooks/useDecoratedUrl.ts
+++ b/src/hooks/useDecoratedUrl.ts
@@ -1,0 +1,70 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import urlFormatter, { type UrlObject } from "url";
+
+const __getQueryParams = (regex?: RegExp): URLSearchParams => {
+  const searchParams = new URLSearchParams(window.location.search);
+  const params = new URLSearchParams();
+
+  Object.keys(Object.fromEntries(searchParams.entries()))
+    .filter((key) => (regex ? key.toLowerCase().match(regex) : true))
+    .forEach((key) => {
+      const value = searchParams.get(key);
+      if (value || value === "") {
+        params.append(key, value);
+      }
+    });
+
+  return params;
+};
+
+const __decorateUrl = (url: string, params: URLSearchParams): URL => {
+  const base = new URL(url, window.location.origin);
+  const currentParams = new URLSearchParams(base.searchParams.toString());
+
+  Object.keys(Object.fromEntries(params.entries()))
+    .filter((key) => !currentParams.has(key))
+    .forEach((key) => {
+      const value = params.get(key);
+
+      if (value) {
+        base.searchParams.append(key, value);
+      }
+    });
+
+  return base;
+};
+
+const useDecoratedUrl = (href: string | UrlObject, regex: RegExp): string => {
+  const [decoratedUrl, setDecoratedUrl] = useState<string | null>(null);
+  const [isClient, setIsClient] = useState<boolean>(false);
+
+  const url = useMemo(() => {
+    const url =
+      typeof href === "object" ? urlFormatter.format(href)?.trim() : href;
+
+    if (isClient) {
+      const queryParams = __getQueryParams();
+      const decorated = __decorateUrl(url, queryParams);
+
+      return decorated.toString();
+    }
+
+    return url;
+  }, [href, isClient]);
+
+  useEffect(() => {
+    if (window) {
+      setIsClient(true);
+    }
+
+    return () => {
+      setIsClient(false);
+    };
+  }, []);
+
+  return decoratedUrl || url;
+};
+
+export default useDecoratedUrl;


### PR DESCRIPTION
## Description

Override the default `next/link` component to support the new `@/components/ui/Link`, which will replace the URL with  UTMs query params (`utm_*`).


## Testing

Navigate to the preview link and add testing UTMs params (ie. `utm_source=[source]&utm_medium=[medium]&other=[value]`)... Click the links and confirm the params persist.

## Links
Preview URL: https://langflow-org-git-feature-utms-datastax-marketing.vercel.app/