### PR TITLE
feat: adds Ketch consent management page and banner

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -75,6 +75,12 @@ export default function RootLayout({
             `,
           }}
         />
+        <Script
+          strategy="afterInteractive"
+          dangerouslySetInnerHTML={{
+            __html: `!function(){window.semaphore=window.semaphore||[],window.ketch=function(){window.semaphore.push(arguments)};var e=document.createElement("script");e.type="text/javascript",e.src="https://global.ketchcdn.com/web/v3/config/datastax/langflow_org_web/boot.js",e.defer=e.async=!0,document.getElementsByTagName("head")[0].appendChild(e)}();`,
+          }}
+        />
       </head>
       <body>
         <main className="layout layout-dark">{children}</main>

--- a/src/app/preferences/page.tsx
+++ b/src/app/preferences/page.tsx
@@ -1,0 +1,24 @@
+//Components
+import Page from "@/components/layout/page";
+import Template from "@/components/pages/Preferences/Template";
+import type { Metadata } from "next";
+import { Suspense } from "react";
+
+export const generateMetadata = (): Metadata => {
+  return {
+    title: "Cookie Preferences | Langflow",
+    description: "Langflow Cookie Preferences",
+  };
+};
+
+const Desktop = async () => {
+  return (
+    <Page className="layout " type="desktop">
+      <Suspense fallback={<div>Loading...</div>}>
+        <Template />
+      </Suspense>
+    </Page>
+  );
+};
+
+export default Desktop;

--- a/src/components/pages/Preferences/Template/Template.tsx
+++ b/src/components/pages/Preferences/Template/Template.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { useEffect } from "react";
+import { CustomWindow } from "@/lib/types/window";
+
+declare let window: CustomWindow;
+
+const Template = () => {
+  function experienceClosed(reason: string) {
+    if (reason != "willNotShow") {
+      if (document.referrer && document.referrer !== document.location.href) {
+        window.location.href = document.referrer;
+      } else {
+        window.location.href = "/";
+      }
+    }
+  }
+
+  useEffect(() => {
+    // Only access window on client side
+    if (typeof window !== "undefined" && window.ketch) {
+      const ketch = window.ketch;
+      ketch("showExperience");
+      ketch("on", "hideExperience", experienceClosed);
+    }
+  }, []);
+
+  return <></>;
+};
+
+export default Template;

--- a/src/components/pages/Preferences/Template/index.ts
+++ b/src/components/pages/Preferences/Template/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./Template";

--- a/src/components/ui/footer/Footer.tsx
+++ b/src/components/ui/footer/Footer.tsx
@@ -4,6 +4,7 @@ import Social from "@/components/ui/Social";
 
 // Styles
 import styles from "./styles.module.scss";
+import Link from "../Link";
 
 const Footer = () => {
   return (
@@ -22,18 +23,25 @@ const Footer = () => {
               {`© ${new Date().getFullYear()}. All rights reserved`}
             </Display>
           </div>
+          <div className={styles.left}>
+            <Display
+              size={100}
+              weight={600}
+              className={styles.innerContainer_font}
+            >
+              ·
+            </Display>
+          </div>
 
-          {/* <div className={styles.left}>
+          <div className={styles.left}>
             <Display
               size={100}
               weight={400}
               className={styles.innerContainer_font}
             >
-              <Link href={"/preferences"} target="_blank">
-                {"Manage Privacy Choices"}
-              </Link>
+              <Link href={"/preferences"}>{"Manage Privacy Choices"}</Link>
             </Display>
-          </div> */}
+          </div>
         </div>
       </div>
     </section>

--- a/src/components/ui/footer/styles.module.scss
+++ b/src/components/ui/footer/styles.module.scss
@@ -22,7 +22,7 @@
   width: 100%;
   display: flex;
   align-items: center;
-  gap: 16px;
+  gap: 8px;
 
   @include media-breakpoint-down(sm) {
     justify-content: center;


### PR DESCRIPTION
This pull request introduces functionality to manage cookie preferences and privacy choices, integrates a third-party script for user experience management, and updates the footer design. Below is a summary of the most important changes categorized by theme.

### Cookie Preferences and Privacy Management:

* **Added a new `Preferences` page**: Created a new `Preferences` page (`src/app/preferences/page.tsx`) with metadata and a `Template` component to handle cookie preferences. This page uses `Suspense` for lazy loading.
* **Implemented `Template` component**: Added the `Template` component (`src/components/pages/Preferences/Template/Template.tsx`) to manage user interactions with the third-party script (`window.ketch`) for privacy choices. Includes logic to redirect users based on the experience closure reason.
* **Exported `Template` component**: Created an index file (`src/components/pages/Preferences/Template/index.ts`) to export the `Template` component for easier imports.

### Third-Party Script Integration:

* **Injected third-party script**: Added a script in `RootLayout` (`src/app/layout.tsx`) to integrate the Ketch platform for managing user experiences related to privacy and cookies.

### Footer Updates:

* **Updated footer design**: Adjusted the footer layout in `Footer.tsx` to include a privacy management link (`Manage Privacy Choices`) without opening in a new tab, and added a visual separator.
* **Modified footer styles**: Reduced the gap between footer elements in `styles.module.scss` to improve visual alignment.