### PR TITLE
Add friendly redirects

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -4,6 +4,31 @@ const nextConfig = {
   redirects: async () => {
     return [
       {
+        source: "/discord",
+        destination: "https://discord.com/invite/EqksyE2EX9",
+        permanent: false,
+      },
+      {
+        source: "/github",
+        destination: "https://github.com/langflow-ai/langflow",
+        permanent: false,
+      },
+      {
+        source: "/twitter",
+        destination: "https://x.com/langflow_ai",
+        permanent: false,
+      },
+      {
+        source: "/youtube",
+        destination: "https://www.youtube.com/@langflow",
+        permanent: false,
+      },
+      {
+        source: "/x",
+        destination: "https://x.com/langflow_ai",
+        permanent: false,
+      },
+      {
         source: "/docs",
         destination: "https://docs.langflow.org",
         permanent: false,


### PR DESCRIPTION
We often can't remember the Discord invite link. This PR adds friendly redirects for:

- `/discord` → https://discord.com/invite/EqksyE2EX9
- `/twitter`, `/x` → https://x.com/langflow_ai
- `/youtube` → https://youtube.com/@langflow
- `/github` → https://github.com/langflow-ai/langflow