### PR TITLE
Changed container width

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -79,44 +79,74 @@ const BlogPostPage: NextPage<{ params: { slug: string } }> = async ({
   return (
     <PageLayout className="layout" type="normal">
       <BackgroundGradient />
-      <article className="d-flex flex-column gap-4 p-4 blog-article">
-        <ol className="list-unstyled p-0 d-flex gap-2 text-white w-100 m-0">
-          <li>
-            <Text size={100}>
-              <a href="/">Home</a>&nbsp;&nbsp;/
-            </Text>
-          </li>
-          <li>
-            <Text size={100}>
-              <a href="/blog">Blog</a>&nbsp;&nbsp;/
-            </Text>
-          </li>
-          <li className="active text-white" aria-current="page">
-            <Text size={100}>{post.title}</Text>
-          </li>
-        </ol>
-        <Display size={700} tagName="h1" className="m-0">
-          {post.title}
-        </Display>
-        <Byline
-          author={post.author || { name: "Unknown" }}
-          publishedAt={post.publishedAt || ""}
-        />
-        <Text size={300} tagName="div" className="article d-grid gap-4">
-          <Markdown>{post.body}</Markdown>
-        </Text>
-        <hr className="my-4 border-top border-light" />
-        <Display size={600} tagName="h2" className="m-0">
-          Similar Posts
-        </Display>
-        <div className="other-posts">
-          {otherPosts.map((post) => (
-            <div key={post._id}>
-              <Post post={post} />
-            </div>
-          ))}
+      <header className="container">
+        <div className="row">
+          <div className="col d-flex flex-column gap-4 p-4">
+            <ol className="list-unstyled p-0 d-flex gap-2 text-white w-100 m-0">
+              <li>
+                <Text size={100}>
+                  <a href="/">Home</a>&nbsp;&nbsp;/
+                </Text>
+              </li>
+              <li>
+                <Text size={100}>
+                  <a href="/blog">Blog</a>&nbsp;&nbsp;/
+                </Text>
+              </li>
+              <li className="active text-white" aria-current="page">
+                <Text size={100}>{post.title}</Text>
+              </li>
+            </ol>
+            <Display size={700} tagName="h1" className="m-0">
+              {post.title}
+            </Display>
+            <Byline
+              author={post.author || { name: "Unknown" }}
+              publishedAt={post.publishedAt || ""}
+            />
+          </div>
+        </div>
+      </header>
+
+      <article className="container blog-article">
+        <div className="row">
+          <Text
+            size={300}
+            tagName="div"
+            className="col d-flex flex-column gap-4"
+          >
+            <Markdown>{post.body}</Markdown>
+          </Text>
         </div>
       </article>
+
+      {otherPosts && (
+        <section className="container">
+          <div className="row my-4">
+            <div className="col">
+              <hr className="my-4 border-top border-light" />
+
+              <Display size={600} tagName="h2" className="m-0">
+                Similar Posts
+              </Display>
+            </div>
+          </div>
+          <div className="row">
+            <div className="col other-posts">
+              {otherPosts.map((post) => (
+                <div key={post._id}>
+                  <Post post={post} />
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+      )}
+
+      {/* <article className="d-flex flex-column gap-4 p-4 blog-article">
+        
+        
+      </article> */}
     </PageLayout>
   );
 };

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -47,25 +47,40 @@ const BlogIndex: NextPage = async () => {
   return (
     <PageLayout className="layout" type="normal">
       <BackgroundGradient />
-      <section
-        id="blog-section"
-        className="container d-grid gap-4 p-4 position-relative"
-      >
-        <Display size={700} tagName="h1">
-          Blog
-        </Display>
-        <SearchAskField className="position-relative z-3" />
-        {latestPost && <LatestPost post={latestPost} />}
-        <Display size={400} style={{ paddingLeft: 11, paddingTop: "1rem" }}>
-          Older Posts
-        </Display>
-        <PostsFeed
-          initialPosts={initialOtherPosts}
-          initialOffset={postsWithExcerpts.length}
-          limit={LIMIT}
-        />
-        <LinesOverlay />
+      <section className="container py-4">
+        <div className="row">
+          <div className="col d-grid gap-4">
+            <Display size={700} tagName="h1">
+              Blog
+            </Display>
+            <SearchAskField className="position-relative z-3" />
+          </div>
+        </div>
       </section>
+
+      {latestPost && (
+        <section className="container">
+          <div className="row">
+            <div className="col">
+              <div className="d-grid gap-4 position-relative" id="blog-section">
+                <LatestPost post={latestPost} />
+                <Display
+                  size={400}
+                  style={{ paddingLeft: 11, paddingTop: "1rem" }}
+                >
+                  Older Posts
+                </Display>
+                <PostsFeed
+                  initialPosts={initialOtherPosts}
+                  initialOffset={postsWithExcerpts.length}
+                  limit={LIMIT}
+                />
+                <LinesOverlay />
+              </div>
+            </div>
+          </div>
+        </section>
+      )}
     </PageLayout>
   );
 };

--- a/src/app/events/page.tsx
+++ b/src/app/events/page.tsx
@@ -1,24 +1,21 @@
 // Dependencies
-import type { Metadata } from 'next';
-import { Suspense } from 'react';
+import type { Metadata } from "next";
 
 //Components
-import Page from '@/components/layout/page';
-import Template from '@/components/pages/EventsHub/Template';
+import Page from "@/components/layout/page";
+import Template from "@/components/pages/EventsHub/Template";
 
 export const generateMetadata = (): Metadata => {
   return {
-    title: 'Events | Langflow',
-    description: 'Langflow Events'
+    title: "Events | Langflow",
+    description: "Langflow Events",
   };
 };
 
 const EventsPage = async () => {
   return (
     <Page className="layout " type="normal">
-      <Suspense fallback={<div>Loading...</div>}>
-        <Template />
-      </Suspense>
+      <Template />
     </Page>
   );
 };

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -62,9 +62,7 @@ export default function RootLayout({
       <head>
         <HeaderScripts />
       </head>
-      <body>
-        <main className="layout layout-dark">{children}</main>
-      </body>
+      <body className="layout layout-dark">{children}</body>
     </html>
   );
 }

--- a/src/components/layout/page/Page.tsx
+++ b/src/components/layout/page/Page.tsx
@@ -31,19 +31,21 @@ const Page: FC<Props> = ({
     home: {
       title:
         "IBM Acquires DataStax, Accelerating Production AI & NoSQL Data at Scale",
-      linkTo: "https://www.datastax.com/blog/datastax-joins-ibm?utm_medium=display&utm_source=langflow&utm_campaign=ibm-close-2025&utm_content=home_banner",
+      linkTo:
+        "https://www.datastax.com/blog/datastax-joins-ibm?utm_medium=display&utm_source=langflow&utm_campaign=ibm-close-2025&utm_content=home_banner",
       linkText: "Read more",
     },
     desktop: {
       title:
         "IBM Acquires DataStax, Accelerating Production AI & NoSQL Data at Scale",
-      linkTo: "https://www.datastax.com/blog/datastax-joins-ibm?utm_medium=display&utm_source=langflow&utm_campaign=ibm-close-2025&utm_content=home_banner",
+      linkTo:
+        "https://www.datastax.com/blog/datastax-joins-ibm?utm_medium=display&utm_source=langflow&utm_campaign=ibm-close-2025&utm_content=home_banner",
       linkText: "Read more",
     },
   };
   return (
-    <div className={styles.container}>
-      <div className={styles.header}>
+    <>
+      <header className={styles.header}>
         {type !== "normal" && (
           <Topbar
             title={topbarContent[type].title}
@@ -52,7 +54,8 @@ const Page: FC<Props> = ({
           />
         )}
         <Header />
-      </div>
+      </header>
+
       <main
         className={`${className} ${legacy ? "legacy" : ""}`}
         id={"page"}
@@ -64,7 +67,7 @@ const Page: FC<Props> = ({
       <Footer />
 
       {isDrafMode && <Preview />}
-    </div>
+    </>
   );
 };
 

--- a/src/components/pages/Event/Content/Content.tsx
+++ b/src/components/pages/Event/Content/Content.tsx
@@ -18,7 +18,7 @@ const Content: FC<Props> = ({ content }) => {
     <section className={styles.content}>
       <div className="container">
         <div className="row">
-          <div className="col-lg-9">
+          <div className="col">
             <Text className={styles.article} size={300} tagName="article">
               <Markdown>{content}</Markdown>
             </Text>

--- a/src/components/pages/EventsHub/Grid/Card/Card.tsx
+++ b/src/components/pages/EventsHub/Grid/Card/Card.tsx
@@ -24,7 +24,9 @@ const Card: FC<Props> = ({ event }) => {
   return (
     <div className={`row ${styles.card}`}>
       <div className="col-lg-4">
-        <Image image={event.thumbnail} alt={event.title} />
+        <Link href={event.slug}>
+          <Image image={event.thumbnail} alt={event.title} />
+        </Link>
       </div>
       <div className="col-lg-8 d-flex flex-column align-items-start">
         <Display className={styles.info} size={100} tagName="div">
@@ -33,13 +35,15 @@ const Card: FC<Props> = ({ event }) => {
           <span>{getEventDate(event.dates)}</span>
         </Display>
 
-        <Display size={300} tagName="h4">
-          {event.title}
-        </Display>
+        <Link href={event.slug}>
+          <Display size={300} tagName="h4">
+            {event.title}
+          </Display>
+        </Link>
         <Text size={200} tagName="p">
           {event.description}
         </Text>
-        <a href={event.slug}>
+        <Link href={event.slug}>
           <span>Learn More</span>
           <svg
             width="6"
@@ -53,7 +57,7 @@ const Card: FC<Props> = ({ event }) => {
               fill="currentColor"
             ></path>
           </svg>
-        </a>
+        </Link>
       </div>
     </div>
   );

--- a/src/components/pages/EventsHub/Grid/Card/styles.module.scss
+++ b/src/components/pages/EventsHub/Grid/Card/styles.module.scss
@@ -10,8 +10,9 @@
     margin-bottom: var(--spacer-2);
   }
 
-  h4 {
+  a:has(h4) {
     margin-bottom: var(--spacer-3);
+    color: inherit;
   }
 
   img {
@@ -26,7 +27,7 @@
     margin-bottom: var(--spacer-3);
   }
 
-  a {
+  a:not(:has(h4)) {
     margin-top: auto;
     color: var(--primary-white);
     font-weight: 600;

--- a/src/components/pages/EventsHub/Hero/Hero.tsx
+++ b/src/components/pages/EventsHub/Hero/Hero.tsx
@@ -12,8 +12,8 @@ const Hero: FC = () => {
   return (
     <section className={styles.hero}>
       <div className="container">
-        <div className="row align-items-center justify-content-between">
-          <div className="col-lg-6">
+        <div className="row">
+          <div className="col">
             <Display size={500} tagName="h1">
               Events
             </Display>

--- a/src/components/pages/EventsHub/Template/Template.tsx
+++ b/src/components/pages/EventsHub/Template/Template.tsx
@@ -1,3 +1,6 @@
+// Dependencies
+import { Suspense } from "react";
+
 // Components
 import Grid from "@/components/pages/EventsHub/Grid";
 import Hero from "@/components/pages/EventsHub/Hero";
@@ -6,7 +9,9 @@ const Template = () => {
   return (
     <>
       <Hero />
-      <Grid />
+      <Suspense>
+        <Grid />
+      </Suspense>
     </>
   );
 };

--- a/src/components/pages/Page/Template/Template.tsx
+++ b/src/components/pages/Page/Template/Template.tsx
@@ -10,6 +10,9 @@ import Display from "@/components/ui/Display";
 import { Markdown } from "@/components/ui/Blog/Markdown";
 import { BackgroundGradient } from "@/components/BackgroundGradient";
 
+// Styles
+import styles from "./styles.module.scss";
+
 type Props = {
   page: PageType;
 };
@@ -20,21 +23,22 @@ const Template: FC<Props> = ({ page }) => {
   return (
     <>
       <BackgroundGradient />
-      <article
-        className="d-flex flex-column gap-4 blog-article"
-        style={{
-          padding: "1.5rem",
-          paddingTop: `7.225rem`,
-          minHeight: "100dvh",
-        }}
-      >
-        <Display size={700} tagName="h1" className="m-0">
-          {title}
-        </Display>
+      <article className={`container ${styles.article}`}>
+        <div className="row mb-4">
+          <div className="col">
+            <Display size={700} tagName="h1" className="m-0">
+              {title}
+            </Display>
+          </div>
+        </div>
 
-        <Text size={300} tagName="div" className="article d-grid gap-4">
-          {body && <Markdown>{body}</Markdown>}
-        </Text>
+        <div className="row justify-content-center">
+          <div className="col">
+            <Text size={300} tagName="div" className="article d-grid gap-4">
+              {body && <Markdown>{body}</Markdown>}
+            </Text>
+          </div>
+        </div>
       </article>
     </>
   );

--- a/src/components/pages/Page/Template/styles.module.scss
+++ b/src/components/pages/Page/Template/styles.module.scss
@@ -1,0 +1,12 @@
+@import "/src/styles/variables";
+@import "~bootstrap/scss/mixins";
+
+.article {
+  min-height: 100dvh;
+  padding-top: 2rem;
+  padding-bottom: 6rem;
+
+  @include media-breakpoint-up(lg) {
+    padding-top: 7.225rem;
+  }
+}

--- a/src/components/ui/footer/Footer.tsx
+++ b/src/components/ui/footer/Footer.tsx
@@ -8,7 +8,7 @@ import Link from "../Link";
 
 const Footer = () => {
   return (
-    <section className={`${styles.footer}`}>
+    <footer className={`${styles.footer}`}>
       <div className={styles.container}>
         <div className={styles.right}>
           <Social />
@@ -44,7 +44,7 @@ const Footer = () => {
           </div>
         </div>
       </div>
-    </section>
+    </footer>
   );
 };
 

--- a/src/styles/_blog-article.scss
+++ b/src/styles/_blog-article.scss
@@ -1,7 +1,4 @@
 .blog-article {
-  max-width: 1024px;
-  margin: 0 auto;
-
   p {
     font-size: 1.2rem;
   }
@@ -35,12 +32,16 @@
     }
   }
 
-  .other-posts {
-    display: grid;
-    grid-template-columns: repeat(1, 1fr);
-    gap: 1rem;
-    @media (min-width: 768px) {
-      grid-template-columns: repeat(2, 1fr);
-    }
+  + section:last-child {
+    margin-bottom: 6rem;
+  }
+}
+
+.other-posts {
+  display: grid;
+  grid-template-columns: repeat(1, 1fr);
+  gap: 1rem;
+  @media (min-width: 768px) {
+    grid-template-columns: repeat(2, 1fr);
   }
 }


### PR DESCRIPTION
## Description
Events, blog & dynamic pages were using different and smaller container `width` in some pages, this PR changed it to use bootstrap container sizing.

## Links

Check the following pages to confirm they use the same sizing.

- Page: https://langflow-org-git-feature-containerization-datastax-marketing.vercel.app/api/preview?secret=LLmQTjSds5&slug=/build-an-ai-powered-agent-in-minutes
- Event: https://langflow-org-git-feature-containerization-datastax-marketing.vercel.app/api/preview?secret=LLmQTjSds5&slug=/events/the-flow-podcast-featuring-twilio
- Blog Post: https://langflow-org-git-feature-containerization-datastax-marketing.vercel.app/blog/generate-personalized-action-figures-and-mythical-creatures-using-ai-with-langflow