### PR TITLE
Fixing preview endpoint + fixes in metadata

### DIFF
--- a/src/app/[...slug]/page.tsx
+++ b/src/app/[...slug]/page.tsx
@@ -72,13 +72,13 @@ export const generateMetadata = async ({ params: { slug } }: Props) => {
   );
   return {
     title: metadata?.title,
-    // description: metadata?.description,
+    description: metadata?.description || "",
     openGraph: {
       url: `https://www.langflow.org/${metadata?.slug?.current?.replace(/^\//, "")}`,
       title: metadata?.title,
-      // description: metadata?.description,
+      description: metadata?.description || "",
       siteName: "Langflow",
-      images: "/images/logo.png",
+      images: [metadata?.thumbnail ? metadata?.thumbnail : "/images/logo.png"],
     },
   };
 };

--- a/src/app/api/preview/route.ts
+++ b/src/app/api/preview/route.ts
@@ -8,6 +8,7 @@ import { sanityFetch } from "@/lib/backend/sanity/client";
 
 // Queries
 import { VALIDATE_DOCUMENT_BY_SLUG_QUERY } from "@/lib/backend/sanity/queries";
+import { buildPath } from "@/lib/backend/sanity/utils";
 
 // Constants
 const SECRET = process.env.NEXT_SANITY_PREVIEW_SECRET;
@@ -22,12 +23,13 @@ export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const secret = searchParams.get("secret");
   const slug = searchParams.get("slug");
+  const type = searchParams.get("type");
 
   if (secret !== SECRET) {
     return new Response("Invalid token", { status: 401 });
   }
 
-  if (!slug) {
+  if (!slug || !type) {
     return new Response("Invalid payload", { status: 401 });
   }
 
@@ -48,7 +50,8 @@ export async function GET(request: Request) {
   draftMode().enable();
 
   // Redirect to the current preview page
-  redirect(`/${_slug}`);
+  const path = buildPath(slug, type);
+  redirect(path);
 }
 
 export const OPTIONS = async () => {

--- a/src/app/api/revalidate/route.ts
+++ b/src/app/api/revalidate/route.ts
@@ -4,33 +4,15 @@ import { type NextRequest, NextResponse } from "next/server";
 import { parseBody } from "next-sanity/webhook";
 
 // Backend
-import { sanityFetch } from "@/lib/backend/sanity/client";
+import { buildPath } from "@/lib/backend/sanity/utils";
 
 // Constants
 const SECRET = process.env.NEXT_SANITY_REVALIDATE_SECRET;
-const PREFIXES: Record<string, string | null> = {
-  page: null,
-  event: "events/",
-  post: "blog/",
-};
 
 type WebhookPayload = {
   type: string;
   slug?: string;
   lang?: string;
-};
-
-// Helper function to generate the correct path based on slug & page type
-const __buildPath = (slug: string, type: string) => {
-  const prefix = PREFIXES[type];
-  let path = slug.replace(/^\//, "");
-
-  if (prefix) {
-    path = `${prefix.replace(/\/$/, "")}/${path.replace(prefix, "")}`; // ensure the prefix is valid
-  }
-
-  // Ensure the path includes the initial slash
-  return `/${path}`;
 };
 
 export async function POST(req: NextRequest) {
@@ -53,7 +35,7 @@ export async function POST(req: NextRequest) {
     }
 
     const { slug, type } = body;
-    const path = __buildPath(slug, type);
+    const path = buildPath(slug, type);
     await revalidatePath(path);
     return NextResponse.json({ path });
   } catch (err: any) {

--- a/src/app/events/[...slug]/page.tsx
+++ b/src/app/events/[...slug]/page.tsx
@@ -12,7 +12,8 @@ import {
 } from "@/lib/backend/sanity/queries";
 
 // Types
-import { Seo, type Event as PageType } from "@/lib/types/sanity.types";
+import type { Event as PageType } from "@/lib/types/sanity.types";
+import type { Seo } from "@/lib/types/sanity";
 
 // Utilities
 import { parseSlugToString } from "@/lib/utils/str";
@@ -60,12 +61,12 @@ export async function generateStaticParams() {
  */
 export const generateMetadata = async ({ params: { slug } }: Props) => {
   const isDraftMode = (await draftMode()).isEnabled;
-  const parsedSlug = parseSlugToString(slug);
+  const parsedSlug = parseSlugToString(slug).replace(/events\//, "");
   const metadata = await sanityFetch<Seo>(
     METADATA_BY_SLUG_QUERY,
     {
       type: DOCUMENT_TYPE,
-      slugs: [parsedSlug, `/${parsedSlug}`],
+      slugs: [`events/${parsedSlug}`, `/events/${parsedSlug}`],
     },
     isDraftMode
   );
@@ -77,7 +78,7 @@ export const generateMetadata = async ({ params: { slug } }: Props) => {
       title: metadata?.title,
       description: metadata?.description,
       siteName: "Langflow",
-      images: "/images/logo.png",
+      images: [metadata?.thumbnail ? metadata?.thumbnail : "/images/logo.png"],
     },
   };
 };

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -10,6 +10,7 @@ import "@/styles/index.scss";
 
 export const generateMetadata = (): Metadata => {
   return {
+    metadataBase: new URL("https://www.langflow.org"),
     title: "Langflow | Low-code AI builder for agentic and RAG applications",
     description:
       "Langflow is a low-code AI builder for agentic and retrieval-augmented generation (RAG) apps. Code in Python and use any LLM or vector database.",

--- a/src/lib/backend/sanity/queries.ts
+++ b/src/lib/backend/sanity/queries.ts
@@ -19,7 +19,7 @@ export const METADATA_BY_SLUG_QUERY = defineQuery(`
   *[_type == $type && defined(slug.current) && slug.current in $slugs][0] {
     title,
     slug,
-    thumbnail
+    "thumbnail": thumbnail.asset->url
   }
 `);
 

--- a/src/lib/backend/sanity/utils.ts
+++ b/src/lib/backend/sanity/utils.ts
@@ -1,0 +1,18 @@
+const PREFIXES: Record<string, string | null> = {
+  page: null,
+  event: "events/",
+  post: "blog/",
+};
+
+// Helper function to generate the correct path based on slug & page type
+export const buildPath = (slug: string, type: string) => {
+  const prefix = PREFIXES[type];
+  let path = slug.replace(/^\//, "");
+
+  if (prefix) {
+    path = `${prefix.replace(/\/$/, "")}/${path.replace(prefix, "")}`; // ensure the prefix is valid
+  }
+
+  // Ensure the path includes the initial slash
+  return `/${path}`;
+};

--- a/src/lib/types/sanity.ts
+++ b/src/lib/types/sanity.ts
@@ -10,8 +10,9 @@ export type InstantBook = {
 
 export type Seo = {
   title: string;
-  thumbnail?: SanityImageSource;
+  thumbnail?: string;
   slug: SeoSlug;
+  description?: string;
 };
 
 export type EventCard = Required<


### PR DESCRIPTION
The preview endpoint was not firing correctly for documents like blog posts, this is because the slug from sanity doesn't match the actual page URL (ie. `post-slug` instead of `/blog/post-slug`)

This PR changes this to programmatically replace the slug to the correct path based on the document slug + type.

Also, this pr includes changes to the metadata generation to include images + the correct handle of slugs.