### PR TITLE
Support one single author or many authors

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -76,12 +76,21 @@ const BlogPostPage: NextPage<{ params: { slug: string } }> = async ({
     notFound();
   }
 
+  const authors = [
+    ...(post.author ? [post.author] : []),
+    ...(post.authors || []),
+  ];
+
+  if (authors.length === 0) {
+    authors.push({ name: "Unknown" });
+  }
+
   return (
     <PageLayout className="layout" type="normal">
       <BackgroundGradient />
       <header className="container">
         <div className="row">
-          <div className="col d-flex flex-column gap-4 p-4">
+          <div className="col d-flex flex-column gap-4 py-4">
             <ol className="list-unstyled p-0 d-flex gap-2 text-white w-100 m-0">
               <li>
                 <Text size={100}>
@@ -101,7 +110,7 @@ const BlogPostPage: NextPage<{ params: { slug: string } }> = async ({
               {post.title}
             </Display>
             <Byline
-              author={post.author || { name: "Unknown" }}
+              authors={authors}
               publishedAt={post.publishedAt || ""}
             />
           </div>
@@ -123,7 +132,7 @@ const BlogPostPage: NextPage<{ params: { slug: string } }> = async ({
       {otherPosts && (
         <section className="container">
           <div className="row my-4">
-            <div className="col">
+            <div className="col`">
               <hr className="my-4 border-top border-light" />
 
               <Display size={600} tagName="h2" className="m-0">

--- a/src/app/blog/llms-full.txt/route.ts
+++ b/src/app/blog/llms-full.txt/route.ts
@@ -12,11 +12,13 @@ interface Post {
   excerpt?: string;
   body: string;
   publishedAt: string;
-  author: {
+  author?: {
     name?: string;
   };
+  authors?: {
+    name?: string;
+  }[];
 }
-
 
 /**
  * GET /blog/llms-full.txt – returns the full text of every blog post.
@@ -33,12 +35,19 @@ export async function GET(_req: NextRequest): Promise<Response> {
     .map((post) => {
       const url = `${host}/blog/${post.slug?.current ?? ""}`;
       const bodyText = post.body;
+      const author = [
+        post.author ? post.author.name : null,
+        ...(post.authors ? post.authors?.map((author) => author.name) : []),
+        null,
+      ]
+        .filter(Boolean)
+        .join(",");
 
       return (
         `TITLE: ${post.title ?? "Untitled"}` +
         `\nURL: ${url}` +
         `\nPUBLISHED AT: ${post.publishedAt}` +
-        (post.author?.name ? `\nAUTHOR: ${post.author.name}` : "") +
+        (author ? `\nAUTHOR: ${author}` : "") +
         `\nCONTENT:\n${bodyText}` +
         `\n\n===` // delimiter between records
       );

--- a/src/app/blog/rss.xml/route.ts
+++ b/src/app/blog/rss.xml/route.ts
@@ -24,8 +24,16 @@ export async function GET() {
         const postUrl = `https://langflow.org/blog/${post.slug.current}`;
         const pubDate = new Date(post.publishedAt).toUTCString();
         const imageUrl = getImageUrl(post.featureImage);
-        const description = post.excerpt || getBodyText(post.body).substring(0, 200) + "...";
-        
+        const description =
+          post.excerpt || getBodyText(post.body).substring(0, 200) + "...";
+        const author = [
+          post.author ? post.author.name : null,
+          ...(post.authors ? post.authors?.map((author) => author.name) : []),
+          "Unknown",
+        ]
+          .filter(Boolean)
+          .join(",");
+
         return `
     <item>
       <title><![CDATA[${post.title}]]></title>
@@ -33,7 +41,7 @@ export async function GET() {
       <guid isPermaLink="true">${postUrl}</guid>
       <pubDate>${pubDate}</pubDate>
       <description><![CDATA[${description}]]></description>
-      <author>please-reply@langflow.org (${post.author.name})</author>
+      <author>please-reply@langflow.org (${author})</author>
       ${imageUrl ? `<enclosure url="${imageUrl}" length="0" type="image/jpeg" />` : ""}
     </item>`;
       })

--- a/src/components/ui/Blog/Byline.module.scss
+++ b/src/components/ui/Blog/Byline.module.scss
@@ -1,0 +1,8 @@
+.avatars {
+  display: flex;
+  flex-wrap: nowrap;
+
+  img:not(:first-child) {
+    margin-left: -8px;
+  }
+}

--- a/src/components/ui/Blog/Byline.tsx
+++ b/src/components/ui/Blog/Byline.tsx
@@ -1,28 +1,35 @@
 import { SanityImageSource } from "@sanity/image-url/lib/types/types";
+import { AuthorClip } from "@/lib/types/sanity";
 import SanityImage from "../media/SanityImage";
 import Text from "../text";
 
+import styles from "./Byline.module.scss";
+
 type BylineProps = {
-  author: {
-    name: string;
-    slug: {
-      current: string;
-    };
-    avatar: SanityImageSource;
-  };
+  authors: AuthorClip[];
   publishedAt: string;
 };
 
-export function Byline({ author, publishedAt }: BylineProps) {
+export function Byline({ authors, publishedAt }: BylineProps) {
   return (
     <div className="d-flex flex-row items-center gap-2">
-      <SanityImage
-        image={author.avatar}
-        alt={author.name}
-        width={32}
-        height={32}
-        className="rounded-circle"
-      />
+      {authors && (
+        <div className={styles.avatars}>
+          {authors
+            ?.filter((author) => !!author.avatar)
+            .map((author, index) => (
+              <SanityImage
+                image={author.avatar}
+                alt={author.name}
+                width={32}
+                height={32}
+                className="rounded-circle"
+                key={author.slug?.current || index}
+                title={author.name}
+              />
+            ))}
+        </div>
+      )}
       <div className="d-flex flex-column">
         <Text
           size={200}
@@ -30,7 +37,11 @@ export function Byline({ author, publishedAt }: BylineProps) {
           className="text-white"
           style={{ lineHeight: 1.2 }}
         >
-          Written by {author.name}
+          Written by{" "}
+          {authors
+            ?.map((author) => author.name)
+            .join(", ")
+            .replace(/, ([^,]*)$/, " & $1")}
         </Text>
         <Text
           size={200}

--- a/src/components/ui/Blog/LatestPost.tsx
+++ b/src/components/ui/Blog/LatestPost.tsx
@@ -7,6 +7,15 @@ import Button from "../button";
 import { ButtonTypes } from "../button/types";
 
 export async function LatestPost({ post }: { post: BlogPost }) {
+  const authors = [
+    ...(post.author ? [post.author] : []),
+    ...(post.authors || []),
+  ];
+
+  if (authors.length === 0) {
+    authors.push({ name: "Unknown" });
+  }
+
   return (
     <div key={post._id}>
       <Link
@@ -31,7 +40,7 @@ export async function LatestPost({ post }: { post: BlogPost }) {
                   >
                     {post.title}
                   </Display>
-                  <Byline author={post.author} publishedAt={post.publishedAt} />
+                  <Byline authors={authors} publishedAt={post.publishedAt} />
                 </div>
                 {
                   <Text size={300} tagName="p" className="text-white">

--- a/src/components/ui/Blog/Post.tsx
+++ b/src/components/ui/Blog/Post.tsx
@@ -8,6 +8,15 @@ import { ButtonTypes } from "@/components/ui/button/types";
 import { BlogPost } from "@/lib/types/sanity";
 
 export function Post({ post }: { post: BlogPost }) {
+  const authors = [
+    ...(post.author ? [post.author] : []),
+    ...(post.authors || []),
+  ];
+
+  if (authors.length === 0) {
+    authors.push({ name: "Unknown" });
+  }
+
   return (
     <Link
       href={`/blog/${post.slug?.current}`}
@@ -31,7 +40,7 @@ export function Post({ post }: { post: BlogPost }) {
           >
             {post.title}
           </Display>
-          <Byline author={post.author} publishedAt={post.publishedAt} />
+          <Byline authors={authors} publishedAt={post.publishedAt} />
           <Text size={300} tagName="p" className="text-white">
             {post.excerpt}
           </Text>

--- a/src/lib/backend/sanity/queries.ts
+++ b/src/lib/backend/sanity/queries.ts
@@ -126,6 +126,11 @@ export const POST_BY_SLUG_QUERY = defineQuery(`
       name,
       slug,
       avatar
+    },
+    authors[]-> {
+      name,
+      slug,
+      avatar
     }
   }
 `);

--- a/src/lib/backend/sanity/queries.ts
+++ b/src/lib/backend/sanity/queries.ts
@@ -101,6 +101,11 @@ export const BLOG_POSTS_QUERY = defineQuery(`
       name,
       slug,
       avatar
+    },
+    authors[]-> {
+      name,
+      slug,
+      avatar
     }
   }
 `);
@@ -145,6 +150,11 @@ export const BLOG_POSTS_PAGINATED_QUERY = defineQuery(`
     publishedAt,
     featureImage,
     "author": author-> {
+      name,
+      slug,
+      avatar
+    },
+    authors[]-> {
       name,
       slug,
       avatar

--- a/src/lib/types/sanity.ts
+++ b/src/lib/types/sanity.ts
@@ -22,6 +22,12 @@ export type EventCard = Required<
   description: string;
 };
 
+export type AuthorClip = {
+  name: string;
+  slug?: { current: string };
+  avatar?: SanityImageSource;
+}
+
 export type BlogPost = {
   _id: string;
   title: string;
@@ -30,9 +36,6 @@ export type BlogPost = {
   body: string;
   publishedAt: string;
   featureImage: SanityImageSource;
-  author: {
-    name: string;
-    slug: { current: string };
-    avatar: SanityImageSource;
-  };
+  author?: AuthorClip;
+  authors?: AuthorClip[];
 };


### PR DESCRIPTION
## Description
- Support Authors field to the blog post to support many authors. or keep using author field until it is deprecated.

## Preview
- [https://langflow-org-git-feature-authors-datastax-marketing.vercel.app/api/preview?secret=LLmQTjSds5&slug=development-example&type=post](https://langflow-org-git-feature-authors-datastax-marketing.vercel.app/api/preview?secret=LLmQTjSds5&slug=development-example&type=post)

