### PR TITLE
Removes TopBar with IBM news.

### DIFF
--- a/src/components/layout/page/Page.tsx
+++ b/src/components/layout/page/Page.tsx
@@ -6,7 +6,6 @@ import { draftMode } from "next/headers";
 import Header from "@/components/ui/Header";
 import Footer from "@/components/ui/footer";
 import Preview from "@/components/ui/Preview";
-import Topbar from "@/components/ui/Topbar";
 
 // Styles
 import styles from "./styles.module.scss";
@@ -27,32 +26,9 @@ const Page: FC<Props> = ({
 }) => {
   const isDrafMode = draftMode().isEnabled;
 
-  const topbarContent = {
-    home: {
-      title:
-        "IBM Acquires DataStax, Accelerating Production AI & NoSQL Data at Scale",
-      linkTo:
-        "https://www.datastax.com/blog/datastax-joins-ibm?utm_medium=display&utm_source=langflow&utm_campaign=ibm-close-2025&utm_content=home_banner",
-      linkText: "Read more",
-    },
-    desktop: {
-      title:
-        "IBM Acquires DataStax, Accelerating Production AI & NoSQL Data at Scale",
-      linkTo:
-        "https://www.datastax.com/blog/datastax-joins-ibm?utm_medium=display&utm_source=langflow&utm_campaign=ibm-close-2025&utm_content=home_banner",
-      linkText: "Read more",
-    },
-  };
   return (
     <>
       <header className={styles.header}>
-        {type !== "normal" && (
-          <Topbar
-            title={topbarContent[type].title}
-            linkTo={topbarContent[type].linkTo}
-            linkText={topbarContent[type].linkText}
-          />
-        )}
         <Header />
       </header>
 


### PR DESCRIPTION
The IBM deal closed in May, [the DataStax site no longer has a front page take over or a top bar advertising the acquisition](https://www.datastax.com/), I think we can probably safely remove it.

I've left the TopBar component in the code basxe so we can use it again if we need to.