### PR TITLE
Fix nested closing backtick

### DIFF
--- a/src/components/ui/Blog/Markdown.tsx
+++ b/src/components/ui/Blog/Markdown.tsx
@@ -77,7 +77,9 @@ export const Markdown = ({ children }: { children: string }) => {
               )}
             >
               <code>
-                {(props.children?.toString() ?? "").replaceAll("\\```", "```")}
+                {typeof props.children === "string"
+                  ? props.children.replaceAll("\\```", "```")
+                  : props.children}
               </code>
             </pre>
           );

--- a/src/components/ui/Blog/Markdown.tsx
+++ b/src/components/ui/Blog/Markdown.tsx
@@ -31,13 +31,7 @@ export const Markdown = ({ children }: { children: string }) => {
         a: ({ node, ...props }) => {
           if (!props.href) return <span>{props.children}</span>;
 
-          return (
-            <Link
-              href={props.href}
-            >
-              {props.children}
-            </Link>
-          );
+          return <Link href={props.href}>{props.children}</Link>;
         },
         button: ({ node, ...props }) => {
           const { href, variant } = props as any;
@@ -82,7 +76,9 @@ export const Markdown = ({ children }: { children: string }) => {
                 "border overflow-x-auto text-overflow-ellipsis border-dark text-white rounded-2"
               )}
             >
-              <code>{props.children}</code>
+              <code>
+                {(props.children as string).replaceAll("\\```", "```")}
+              </code>
             </pre>
           );
         },

--- a/src/components/ui/Blog/Markdown.tsx
+++ b/src/components/ui/Blog/Markdown.tsx
@@ -77,7 +77,7 @@ export const Markdown = ({ children }: { children: string }) => {
               )}
             >
               <code>
-                {(props.children as string).replaceAll("\\```", "```")}
+                {(props.children?.toString() ?? "").replaceAll("\\```", "```")}
               </code>
             </pre>
           );


### PR DESCRIPTION
This PR helps us create nested backticks in multiline code blocks on the blog.

|Before|After|
|---|---|
|<img width="1212" height="549" alt="k" src="https://github.com/user-attachments/assets/a4bacbd8-d961-4fb5-8652-f1e09ad0c633" />|<img width="1205" height="532" alt="j" src="https://github.com/user-attachments/assets/99664b9b-babf-4c15-9a0d-be03a3bbc5df" />|
