### PR TITLE
Standardize page title format across application

### DIFF
--- a/src/app/[...slug]/page.tsx
+++ b/src/app/[...slug]/page.tsx
@@ -17,6 +17,7 @@ import { Seo } from "@/lib/types/sanity";
 
 // Utilities
 import { parseSlugToString } from "@/lib/utils/str";
+import { formatOpenGraphTitle } from "@/lib/utils/titles";
 
 // Components
 import PageLayout from "@/components/layout/page";
@@ -75,7 +76,7 @@ export const generateMetadata = async ({ params: { slug } }: Props) => {
     description: metadata?.description || "",
     openGraph: {
       url: `https://www.langflow.org/${metadata?.slug?.current?.replace(/^\//, "")}`,
-      title: metadata?.title,
+      title: formatOpenGraphTitle(metadata?.title),
       description: metadata?.description || "",
       siteName: "Langflow",
       images: [metadata?.thumbnail ? metadata?.thumbnail : "/images/logo.png"],

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -17,6 +17,7 @@ import { Post } from "@/components/ui/Blog/Post";
 import { BlogPost } from "@/lib/types/sanity";
 import { Markdown } from "@/components/ui/Blog/Markdown";
 import { BackgroundGradient } from "@/components/BackgroundGradient";
+import { formatOpenGraphTitle } from "@/lib/utils/titles";
 
 export async function generateStaticParams() {
   const slugs = await sanityFetch<string[]>(BLOG_POSTS_SLUGS_QUERY);
@@ -44,10 +45,10 @@ export const generateMetadata = async ({
   const featureImageUrl = getImageUrl(post.featureImage);
 
   return {
-    title: `${post.title} | Langflow - The AI Agent Builder`,
+    title: post.title,
     description: post.excerpt,
     openGraph: {
-      title: post.title,
+      title: formatOpenGraphTitle(post.title),
       description: post.excerpt,
       images: featureImageUrl ? [featureImageUrl] : undefined,
     },
@@ -151,11 +152,6 @@ const BlogPostPage: NextPage<{ params: { slug: string } }> = async ({
           </div>
         </section>
       )}
-
-      {/* <article className="d-flex flex-column gap-4 p-4 blog-article">
-        
-        
-      </article> */}
     </PageLayout>
   );
 };

--- a/src/app/contact-us/page.tsx
+++ b/src/app/contact-us/page.tsx
@@ -8,8 +8,8 @@ import Template from "@/components/pages/ContactUs/Template/Template";
 
 export const generateMetadata = (): Metadata => {
   return {
-    title: "Contact Us | Langflow",
-    description: "Langflow Desktop Application",
+    title: "Contact Us",
+    description: "Get in touch with the Langflow team",
   };
 };
 

--- a/src/app/desktop/page.tsx
+++ b/src/app/desktop/page.tsx
@@ -6,8 +6,8 @@ import { Suspense } from 'react';
 
 export const generateMetadata = (): Metadata => {
   return {
-    title: 'Desktop | Langflow',
-    description: 'Langflow Desktop Application'
+    title: 'Desktop',
+    description: 'Download and use the Langflow Desktop Application'
   };
 };
 

--- a/src/app/events/[...slug]/page.tsx
+++ b/src/app/events/[...slug]/page.tsx
@@ -17,6 +17,7 @@ import type { Seo } from "@/lib/types/sanity";
 
 // Utilities
 import { parseSlugToString } from "@/lib/utils/str";
+import { formatOpenGraphTitle } from "@/lib/utils/titles";
 
 // Components
 import PageLayout from "@/components/layout/page";
@@ -75,7 +76,7 @@ export const generateMetadata = async ({ params: { slug } }: Props) => {
     description: metadata?.description,
     openGraph: {
       url: `https://www.langflow.org/${metadata?.slug?.current?.replace(/^\//, "")}`,
-      title: metadata?.title,
+      title: formatOpenGraphTitle(metadata?.title),
       description: metadata?.description,
       siteName: "Langflow",
       images: [metadata?.thumbnail ? metadata?.thumbnail : "/images/logo.png"],

--- a/src/app/events/page.tsx
+++ b/src/app/events/page.tsx
@@ -7,8 +7,8 @@ import Template from "@/components/pages/EventsHub/Template";
 
 export const generateMetadata = (): Metadata => {
   return {
-    title: "Events | Langflow",
-    description: "Langflow Events",
+    title: "Events",
+    description: "Discover upcoming Langflow events, workshops, and community meetups",
   };
 };
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,6 +6,9 @@ import * as Sentry from "@sentry/nextjs";
 import HeaderScripts from "@/components/scripts/Header";
 import { DataAttributeTracker } from "@/components/DataAttributeTracker";
 
+// Utilities
+import { SITE_NAME, DEFAULT_TAGLINE } from "@/lib/utils/titles";
+
 // Styles
 import "@/styles/index.scss";
 
@@ -15,7 +18,10 @@ export const generateMetadata = (): Metadata => {
       ...Sentry.getTraceData(),
     },
     metadataBase: new URL("https://www.langflow.org"),
-    title: "Langflow | Low-code AI builder for agentic and RAG applications",
+    title: {
+      template: `%s | ${SITE_NAME} | ${DEFAULT_TAGLINE}`,
+      default: `${SITE_NAME} | ${DEFAULT_TAGLINE}`,
+    },
     description:
       "Langflow is a low-code AI builder for agentic and retrieval-augmented generation (RAG) apps. Code in Python and use any LLM or vector database.",
     icons: {
@@ -34,7 +40,7 @@ export const generateMetadata = (): Metadata => {
     creator: "Langflow",
     publisher: "Langflow",
     openGraph: {
-      title: "Langflow | Low-code AI builder for agentic and RAG applications",
+      title: `${SITE_NAME} | ${DEFAULT_TAGLINE}`,
       description:
         "Langflow is a low-code AI builder for agentic and retrieval-augmented generation (RAG) apps. Code in Python and use any LLM or vector database.",
       url: "https://langflow.org",
@@ -50,7 +56,7 @@ export const generateMetadata = (): Metadata => {
     },
     twitter: {
       card: "summary_large_image",
-      title: "Langflow | Low-code AI builder for agentic and RAG applications",
+      title: `${SITE_NAME} | ${DEFAULT_TAGLINE}`,
       description:
         "Langflow is a low-code AI builder for agentic and retrieval-augmented generation (RAG) apps. Code in Python and use any LLM or vector database.",
       images: ["/images/og-image.png"],

--- a/src/app/newsletter/page.tsx
+++ b/src/app/newsletter/page.tsx
@@ -5,7 +5,7 @@ import type { Metadata } from "next";
 
 export const generateMetadata = (): Metadata => {
   return {
-    title: "AI++ Newsletter | Langflow",
+    title: "AI++ Newsletter",
     description:
       "Sign up for the AI++ Newsletter to stay updated with the latest in AI, Agents and MCP.",
   };

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,7 +4,6 @@ import type { Metadata } from "next";
 
 export const generateMetadata = (): Metadata => {
   return {
-    title: "Home | Langflow",
     description: "Welcome to Langflow - Build AI applications with ease",
   };
 };

--- a/src/app/preferences/page.tsx
+++ b/src/app/preferences/page.tsx
@@ -6,8 +6,8 @@ import { Suspense } from "react";
 
 export const generateMetadata = (): Metadata => {
   return {
-    title: "Cookie Preferences | Langflow",
-    description: "Langflow Cookie Preferences",
+    title: "Cookie Preferences",
+    description: "Manage your cookie preferences for the Langflow website",
   };
 };
 

--- a/src/lib/utils/titles.ts
+++ b/src/lib/utils/titles.ts
@@ -1,0 +1,11 @@
+export const DEFAULT_TAGLINE = "Low-code AI builder for agentic and RAG applications";
+export const SITE_NAME = "Langflow";
+
+// Only used for OpenGraph titles since they don't use Next.js template system
+export function formatOpenGraphTitle(pageTitle?: string): string {
+  if (!pageTitle) {
+    return `${SITE_NAME} | ${DEFAULT_TAGLINE}`;
+  }
+
+  return `${pageTitle} | ${SITE_NAME} | ${DEFAULT_TAGLINE}`;
+}


### PR DESCRIPTION
Standardize all page titles to use consistent format: 

Home page:
`Langflow | Low-code AI builder for agentic and RAG applications`

Sub pages:
`{Page} | Langflow | Low-code AI builder for agentic and RAG applications`
